### PR TITLE
use opts

### DIFF
--- a/lib/clickhousex/protocol.ex
+++ b/lib/clickhousex/protocol.ex
@@ -165,12 +165,12 @@ defmodule Clickhousex.Protocol do
 
   ## Private functions
 
-  defp do_query(query, params, _opts, state) do
-    base_address = state.base_address
-    username = state.conn_opts[:username]
-    password = state.conn_opts[:password]
-    timeout = state.conn_opts[:timeout]
-    database = state.conn_opts[:database]
+  defp do_query(query, params, opts, state) do
+    %{base_address: base_address, conn_opts: conn_opts} = state
+    username = opts[:username] || conn_opts[:username]
+    password = opts[:password] || conn_opts[:password]
+    timeout = opts[:timeout] || conn_opts[:timeout]
+    database = opts[:database] || conn_opts[:database]
 
     query
     |> Client.send(params, base_address, timeout, username, password, database)


### PR DESCRIPTION
For passing `opts` on per-query basis like:

```elixir
ClickhouseRepo.query("select * from table", [], timeout: :timer.seconds(30))
```

---

```elixir
iex(1)> defmodule Repo do                                    
...(1)>   use Ecto.Repo, adapter: ClickhouseEcto, otp_app: :eh
...(1)> end
{:module, Repo,
 <<70, 79, 82, 49, 0, 0, 52, 140, 66, 69, 65, 77, 65, 116, 85, 56, 0, 0, 3, 80,
   0, 0, 0, 80, 11, 69, 108, 105, 120, 105, 114, 46, 82, 101, 112, 111, 8, 95,
   95, 105, 110, 102, 111, 95, 95, 10, 97, ...>>, :ok}

iex(9)>  Application.put_env(:eh, Repo, timeout: :timer.seconds(15), hostname: "localhost", port: 8123, database: "default", pool_size: 10, pool_timeout: :timer.seconds(60), ownership_timeout: :timer.seconds(60))
:ok

iex(10)> Repo.start_link()
warning: :pool_timeout option no longer has an effect and has been replaced with an improved queuing system.
See "Queue config" in DBConnection.start_link/2 documentation for more information.

  (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:469: Ecto.Adapters.SQL.adapter_config/1
  (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:456: Ecto.Adapters.SQL.init/3
  (ecto 3.3.3) lib/ecto/repo/supervisor.ex:172: Ecto.Repo.Supervisor.init/1
  (stdlib 4.0.1) supervisor.erl:330: :supervisor.init/1
  (stdlib 4.0.1) gen_server.erl:848: :gen_server.init_it/2
  (stdlib 4.0.1) gen_server.erl:811: :gen_server.init_it/6

{:ok, #PID<0.493.0>}
```

```elixir
# fail after 15s
iex(11)> Repo.query("select * from system.numbers where sleepEachRow(0.05) limit 10")                                                                                                                                
15:51:14.331 [error] Clickhousex.Protocol (#PID<0.503.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.452.0> timed out because it queued and checked out the connection for longer than 15000ms

#PID<0.452.0> was at location:

    :prim_inet.recv0/3
    (hackney 1.16.0) /Users/q/Developer/plausible/forks/clickhouse_ecto/deps/hackney/src/hackney_response.erl:76: :hackney_response.wait_status/1
    (hackney 1.16.0) /Users/q/Developer/plausible/forks/clickhouse_ecto/deps/hackney/src/hackney.erl:376: :hackney.send_request/2
    (httpoison 1.7.0) lib/httpoison/base.ex:796: HTTPoison.Base.request/6
    (clickhousex 0.4.0) lib/clickhousex/http_client.ex:31: Clickhousex.HTTPClient.send_p/5
    (clickhousex 0.4.0) lib/clickhousex/protocol.ex:176: Clickhousex.Protocol.do_query/4
    (db_connection 2.4.2) lib/db_connection/holder.ex:354: DBConnection.Holder.holder_apply/4
    (db_connection 2.4.2) lib/db_connection.ex:1364: DBConnection.run_execute/5

 
15:51:14.332 [debug] QUERY ERROR db=15001.8ms idle=1701.5ms
select * from system.numbers where sleepEachRow(0.05) limit 10 []
{:error,
 %Clickhousex.Error{
   message: "timeout",
   code: :unknown,
   constraint_violations: []
 }}
```
```elixir
# fail after 60sec
iex(12)> Repo.query("select * from system.numbers where sleepEachRow(0.05) limit 10", [], timeout: :timer.seconds(60))

15:52:37.665 [error] Clickhousex.Protocol (#PID<0.497.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.452.0> timed out because it queued and checked out the connection for longer than 60000ms

#PID<0.452.0> was at location:

    :prim_inet.recv0/3
    (hackney 1.16.0) /Users/q/Developer/plausible/forks/clickhouse_ecto/deps/hackney/src/hackney_response.erl:76: :hackney_response.wait_status/1
    (hackney 1.16.0) /Users/q/Developer/plausible/forks/clickhouse_ecto/deps/hackney/src/hackney.erl:376: :hackney.send_request/2
    (httpoison 1.7.0) lib/httpoison/base.ex:796: HTTPoison.Base.request/6
    (clickhousex 0.4.0) lib/clickhousex/http_client.ex:31: Clickhousex.HTTPClient.send_p/5
    (clickhousex 0.4.0) lib/clickhousex/protocol.ex:176: Clickhousex.Protocol.do_query/4
    (db_connection 2.4.2) lib/db_connection/holder.ex:354: DBConnection.Holder.holder_apply/4
    (db_connection 2.4.2) lib/db_connection.ex:1364: DBConnection.run_execute/5

 
15:52:37.666 [debug] QUERY ERROR db=60001.8ms idle=27.8ms
select * from system.numbers where sleepEachRow(0.05) limit 10 []
{:error,
 %Clickhousex.Error{
   message: "timeout",
   code: :unknown,
   constraint_violations: []
 }}
```