### PR TITLE
Encoding map objects to string during escaping process

### DIFF
--- a/lib/clickhousex/codec/values.ex
+++ b/lib/clickhousex/codec/values.ex
@@ -105,8 +105,7 @@ defmodule Clickhousex.Codec.Values do
   end
 
   defp escape(s) when is_map(s) do
-    m = Jason.encode!(s)
-    to_iodata(m, 0, m, [])
+    Jason.encode_to_iodata!(s)
   end
 
   defp escape(s) do

--- a/lib/clickhousex/codec/values.ex
+++ b/lib/clickhousex/codec/values.ex
@@ -105,7 +105,8 @@ defmodule Clickhousex.Codec.Values do
   end
 
   defp escape(s) when is_map(s) do
-    Jason.encode_to_iodata!(s)
+    m = Jason.encode!(s)
+    to_iodata(m, 0, m, [])
   end
 
   defp escape(s) do

--- a/lib/clickhousex/codec/values.ex
+++ b/lib/clickhousex/codec/values.ex
@@ -104,6 +104,11 @@ defmodule Clickhousex.Codec.Values do
     ["'", escape(param), "'"]
   end
 
+  defp escape(s) when is_map(s) do
+    m = Jason.encode!(s)
+    to_iodata(m, 0, m, [])
+  end
+
   defp escape(s) do
     to_iodata(s, 0, s, [])
   end


### PR DESCRIPTION
Encoding of incoming data in map format to JSON to prevent an error like those below

```
** (FunctionClauseError) no function clause matching in Clickhousex.Codec.Values.to_iodata/4
    (clickhousex 0.4.0) lib/clickhousex/codec/values.ex:120: Clickhousex.Codec.Values.to_iodata(%{"key" => "value"}, 0, %{"key" => "value"}, [])
    (clickhousex 0.4.0) lib/clickhousex/codec/values.ex:104: Clickhousex.Codec.Values.encode_param/2
    (clickhousex 0.4.0) lib/clickhousex/codec/values.ex:39: Clickhousex.Codec.Values.weave/4
    (clickhousex 0.4.0) lib/clickhousex/query.ex:53: DBConnection.Query.Clickhousex.Query.encode/3
    (db_connection 2.4.2) lib/db_connection.ex:1255: DBConnection.encode/5
    (db_connection 2.4.2) lib/db_connection.ex:1355: DBConnection.run_prepare_execute/5
    (db_connection 2.4.2) lib/db_connection.ex:1459: DBConnection.run/6
    (db_connection 2.4.2) lib/db_connection.ex:595: DBConnection.parsed_prepare_execute/5
    (db_connection 2.4.2) lib/db_connection.ex:587: DBConnection.prepare_execute/4
    (clickhousex 0.4.0) lib/clickhousex.ex:59: Clickhousex.query/4
    (ecto_sql 3.9.0) lib/ecto/adapters/sql.ex:432: Ecto.Adapters.SQL.query!/4
    (ecto_sql 3.9.0) lib/ecto/adapters/sql.ex:795: Ecto.Adapters.SQL.insert_all/9
    (ecto 3.9.1) lib/ecto/repo/schema.ex:59: Ecto.Repo.Schema.do_insert_all/7
    (stdlib 4.1.1) gen_server.erl:1161: :gen_server.try_terminate/3
    (stdlib 4.1.1) gen_server.erl:1351: :gen_server.terminate/10
    (stdlib 4.1.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

It happened when I tried to save data in the JSON field. The Clickhouse supports that as an experimental feature (https://clickhouse.com/docs/en/sql-reference/data-types/json/). 